### PR TITLE
Resolve C++20 warning

### DIFF
--- a/src/parse.hpp
+++ b/src/parse.hpp
@@ -1147,7 +1147,7 @@ private:
 
 		if (c < ' ') {
 			char hexString[5];
-			std::sprintf(hexString, "\\x%02X", c);
+			std::snprintf(hexString, sizeof(hexString),  "\\x%02X", c);
 			return hexString;
 		}
 

--- a/src/stringify.hpp
+++ b/src/stringify.hpp
@@ -214,7 +214,7 @@ private:
 
 			if (c < ' ') {
 				char hexString[5];
-				std::sprintf(hexString, "\\x%02x", c);
+				std::snprintf(hexString, sizeof(hexString),  "\\x%02X", c);
 				product += hexString;
 				continue;
 			};


### PR DESCRIPTION
Using std:sprintf gives a warning in C++20 because it is a deprecated function, I propose to change it to snprintf.
I am using this library in a project and my paranoia includes -Wall -Werrror :D 
Thank you,
A.
